### PR TITLE
Include headless mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ alpine-slim:
 
 test-container:
 	"$(BUILDER)" run "$(IMAGE)" weechat --version
+        "$(BUILDER)" run "$(IMAGE)" weechat-headless --version
 
 lint: flake8 pylint mypy bandit
 

--- a/alpine/Containerfile
+++ b/alpine/Containerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
             .. \
             -DCMAKE_INSTALL_PREFIX=/opt/weechat \
             -DENABLE_MAN=ON \
-	          -DENABLE_HEADLESS=ON \
+            -DENABLE_HEADLESS=ON \
         ; \
     else \
         cmake \
@@ -103,6 +103,7 @@ RUN set -eux; \
             -DENABLE_SCRIPT=OFF \
             -DENABLE_SCRIPTS=OFF \
             -DENABLE_SPELL=OFF \
+            -DENABLE_HEADLESS=ON \
         ; \
     fi ; \
     make -j $(nproc); \
@@ -125,7 +126,7 @@ RUN set -eux; \
         ncurses-terminfo \
         zlib \
         zstd \
-	      zstd-libs \
+        zstd-libs \
     ; \
     if [ -z "$SLIM" ] ; then \
         apk add --no-cache \

--- a/alpine/Containerfile
+++ b/alpine/Containerfile
@@ -93,6 +93,7 @@ RUN set -eux; \
             .. \
             -DCMAKE_INSTALL_PREFIX=/opt/weechat \
             -DENABLE_MAN=ON \
+	    -DENABLE_HEADLESS=ON \
         ; \
     else \
         cmake \
@@ -124,6 +125,7 @@ RUN set -eux; \
         ncurses-terminfo \
         zlib \
         zstd \
+	zstd-libs \
     ; \
     if [ -z "$SLIM" ] ; then \
         apk add --no-cache \
@@ -143,6 +145,7 @@ RUN set -eux; \
 COPY --from=build /opt/weechat /opt/weechat
 
 RUN ln -sf /opt/weechat/bin/weechat /usr/bin/weechat
+RUN ln -sf /opt/weechat/bin/weechat-headless /usr/bin/weechat-headless
 
 WORKDIR $HOME
 

--- a/alpine/Containerfile
+++ b/alpine/Containerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
             .. \
             -DCMAKE_INSTALL_PREFIX=/opt/weechat \
             -DENABLE_MAN=ON \
-	    -DENABLE_HEADLESS=ON \
+	          -DENABLE_HEADLESS=ON \
         ; \
     else \
         cmake \
@@ -125,7 +125,7 @@ RUN set -eux; \
         ncurses-terminfo \
         zlib \
         zstd \
-	zstd-libs \
+	      zstd-libs \
     ; \
     if [ -z "$SLIM" ] ; then \
         apk add --no-cache \

--- a/debian/Containerfile
+++ b/debian/Containerfile
@@ -96,7 +96,7 @@ RUN set -eux; \
             .. \
             -DCMAKE_INSTALL_PREFIX=/opt/weechat \
             -DENABLE_MAN=ON \
-	    -DENABLE_HEADLESS=ON \
+	          -DENABLE_HEADLESS=ON \
         ; \
     else \
         cmake \

--- a/debian/Containerfile
+++ b/debian/Containerfile
@@ -96,6 +96,7 @@ RUN set -eux; \
             .. \
             -DCMAKE_INSTALL_PREFIX=/opt/weechat \
             -DENABLE_MAN=ON \
+	    -DENABLE_HEADLESS=ON \
         ; \
     else \
         cmake \
@@ -148,6 +149,7 @@ RUN set -eux; \
 COPY --from=build /opt/weechat /opt/weechat
 
 RUN ln -sf /opt/weechat/bin/weechat /usr/bin/weechat
+RUN ln -sf /opt/weechat/bin/weechat-headless /usr/bin/weechat-headless
 
 WORKDIR $HOME
 

--- a/debian/Containerfile
+++ b/debian/Containerfile
@@ -96,7 +96,7 @@ RUN set -eux; \
             .. \
             -DCMAKE_INSTALL_PREFIX=/opt/weechat \
             -DENABLE_MAN=ON \
-	          -DENABLE_HEADLESS=ON \
+            -DENABLE_HEADLESS=ON \
         ; \
     else \
         cmake \
@@ -106,6 +106,7 @@ RUN set -eux; \
             -DENABLE_SCRIPT=OFF \
             -DENABLE_SCRIPTS=OFF \
             -DENABLE_SPELL=OFF \
+            -DENABLE_HEADLESS=ON \
         ; \
     fi ; \
     make -j $(nproc); \


### PR DESCRIPTION
Compile with headless mode enabled for people who are just using weechat as a headless relay. (zstd-libs was also missing from the alpine images).