### PR TITLE
add tzdata for timezone via env

### DIFF
--- a/alpine/Containerfile
+++ b/alpine/Containerfile
@@ -126,6 +126,7 @@ RUN set -eux ; \
         libgcrypt \
         ncurses-libs \
         ncurses-terminfo \
+        tzdata \
         zlib \
         zstd \
         zstd-libs \

--- a/debian/Containerfile
+++ b/debian/Containerfile
@@ -131,6 +131,7 @@ RUN set -eux ; \
         libzstd1 \
         locales \
         ncurses-term \
+        tzdata \
         zlib1g \
     ; \
     if [ -z "$SLIM" ] ; then \


### PR DESCRIPTION
add tzdata for timezone via environment variable from this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (use the tz database name).

Examples

## cli:
`docker run -e TZ=TIMEZONE weechat/weechat`

## compose:
```
environment:
  - TZ=TIMEZONE
```