### PR TITLE
add automated docker build and push workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,38 @@
+name: Build docker image
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        image:
+          - debian
+          - debian-slim
+          - alpine
+          - alpine-slim
+
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Docker Image
+        run: |
+          make ${{ matrix.image }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Push images
+        run: |
+          docker images --format "{{.Repository}}" | grep weechat | \
+          while read image
+          do
+            docker push "${image}"
+          done


### PR DESCRIPTION
## Summary
This workflow will run on new tags pushed to the repo for new version releases. It will build all images per the makefile and build script and push to Docker Hub.

## Requirements
  - create docker hub token
  - add secret to repository for token and username (please check spelling/capitalization exactly or change as preferred).