### PR TITLE
Support cross platform builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ The slim version includes all plugins except these ones:
 - scripting languages: perl, python, ruby, lua, tcl, guile, php
 - spell
 
+## Supported platforms
+
+It's possible to build for different linux platforms other than amd64,
+the only prerequisite is to have `qemu-user-static` package installed
+
+- `linux/386`
+- `linux/amd64`
+- `linux/arm/v6`
+- `linux/arm/v7`
+- `linux/arm64`
+- `linux/ppc64le`
+- `linux/s390x`
+
+
 ## Install from Docker Hub
 
 You can install directly the latest version from the Docker Hub:
@@ -70,6 +84,13 @@ Build all images with latest stable version of WeeChat:
 
 ```
 $ make all-images
+```
+
+Build all images with latest stable version of WeeChat for AMD64 and ARM64 platforms
+and push them to the `docker.io/weechat` registry project:
+
+```
+$ make PLATFORMS="linux/amd64 linux/arm64" REGISTRY="docker.io" REGISTRY_PROJECT="weechat" PUSH=true all-images
 ```
 
 Build an Alpine-based image with Podman, slim version, WeeChat 3.6:

--- a/alpine/Containerfile
+++ b/alpine/Containerfile
@@ -18,20 +18,11 @@ ENV VERSION="${VERSION}"
 ARG SLIM=""
 ENV SLIM="${SLIM}"
 
-ARG HOME="/home/user"
+ARG HOME="/weechat"
 ENV HOME="${HOME}"
 
 ENV LANG="C.UTF-8"
 ENV TERM="xterm-256color"
-
-# create a user
-RUN set -eux ; \
-    adduser -u 1001 -D -h "$HOME" user ; \
-    mkdir -p "$HOME/.weechat" ; \
-    mkdir -p "$HOME/.config/weechat" ; \
-    mkdir -p "$HOME/.local/share/weechat" ; \
-    mkdir -p "$HOME/.cache/weechat" ; \
-    chown -R user:user "$HOME"
 
 # ==== build ====
 
@@ -126,6 +117,8 @@ RUN set -eux ; \
         libgcrypt \
         ncurses-libs \
         ncurses-terminfo \
+        shadow \
+        setpriv \
         tzdata \
         zlib \
         zstd \
@@ -151,8 +144,17 @@ COPY --from=build /opt/weechat /opt/weechat
 RUN ln -sf /opt/weechat/bin/weechat /usr/bin/weechat
 RUN ln -sf /opt/weechat/bin/weechat-headless /usr/bin/weechat-headless
 
+# create a user
+RUN set -eux ; \
+  adduser -u 1000 -D -h "$HOME" weechat; \
+  mkdir -p "$HOME/.weechat" ; \
+  mkdir -p "$HOME/.config/weechat" ; \
+  mkdir -p "$HOME/.local/share/weechat" ; \
+  mkdir -p "$HOME/.cache/weechat" ; \
+  chown -R weechat:weechat "$HOME"
+
+ADD ../run.sh /
+
 WORKDIR $HOME
 
-USER user
-
-CMD ["weechat"]
+ENTRYPOINT [ "/run.sh" ]

--- a/debian/Containerfile
+++ b/debian/Containerfile
@@ -18,20 +18,11 @@ ENV VERSION="${VERSION}"
 ARG SLIM=""
 ENV SLIM="${SLIM}"
 
-ARG HOME="/home/user"
+ARG HOME="/weechat"
 ENV HOME="${HOME}"
 
 ENV LANG="C.UTF-8"
 ENV TERM="xterm-256color"
-
-# create a user
-RUN set -eux ; \
-    useradd --create-home --home-dir "$HOME" user ; \
-    mkdir -p "$HOME/.weechat" ; \
-    mkdir -p "$HOME/.config/weechat" ; \
-    mkdir -p "$HOME/.local/share/weechat" ; \
-    mkdir -p "$HOME/.cache/weechat" ; \
-    chown -R user:user "$HOME"
 
 # ==== build ====
 
@@ -41,6 +32,7 @@ LABEL stage=build
 RUN set -eux ; \
     \
     # install download/build dependencies
+    export DEBIAN_FRONTEND="noninteractive"; \
     apt-get update ; \
     apt-get install -y --no-install-recommends \
         asciidoctor \
@@ -121,6 +113,7 @@ FROM base
 RUN set -eux ; \
     \
     # install runtime dependencies
+    export DEBIAN_FRONTEND="noninteractive"; \
     apt-get update ; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -155,8 +148,17 @@ COPY --from=build /opt/weechat /opt/weechat
 RUN ln -sf /opt/weechat/bin/weechat /usr/bin/weechat
 RUN ln -sf /opt/weechat/bin/weechat-headless /usr/bin/weechat-headless
 
+# create a user
+RUN set -eux ; \
+  useradd --create-home --home-dir "$HOME" weechat; \
+  mkdir -p "$HOME/.weechat" ; \
+  mkdir -p "$HOME/.config/weechat" ; \
+  mkdir -p "$HOME/.local/share/weechat" ; \
+  mkdir -p "$HOME/.cache/weechat" ; \
+  chown -R weechat:weechat "$HOME"
+
+ADD ../run.sh /
+
 WORKDIR $HOME
 
-USER user
-
-CMD ["weechat"]
+ENTRYPOINT [ "/run.sh" ]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+usermod -o -u "${PUID:-1000}" weechat 2>&1 > /dev/null
+groupmod -o -g "${PGID:-1000}" weechat 2>&1 > /dev/null
+
+chown -R weechat:weechat /weechat
+
+exec setpriv --reuid weechat --regid weechat --clear-groups /usr/bin/weechat "$@"


### PR DESCRIPTION
Add support for cross building the following platforms:
    
- `linux/386`
- `linux/amd64`
- `linux/arm/v6`
- `linux/arm/v7`
- `linux/arm64`
- `linux/ppc64le`
- `linux/s390x`
    
To build for a different platform other than the local native platform the
`qemu-user-static` package must be installed.
    
Example to build AMD64, ARM64 and ARMv7 platforms:
```
make PLATFORM="linux/amd64 linux/arm64 linux/arm/v7" all-images
```