### PR TITLE
Add `cjson-dev` dependency packages

### DIFF
--- a/alpine/Containerfile
+++ b/alpine/Containerfile
@@ -44,6 +44,7 @@ RUN set -eux ; \
     apk add --no-cache \
         acl-dev \
         asciidoctor \
+        cjson-dev \
         cmake \
         curl \
         curl-dev \

--- a/debian/Containerfile
+++ b/debian/Containerfile
@@ -51,6 +51,7 @@ RUN set -eux ; \
         gcc \
         gettext \
         gnupg \
+        libcjson-dev \
         libcurl3-gnutls-dev \
         libgcrypt20-dev \
         libgnutls28-dev \


### PR DESCRIPTION
Required since WeeChat 4.3 for the "api" protocol relay plugin (HTTP REST API).

Keep up your great work! :clap: 

---

Before fix:

**Alpine**

```
+ cmake .. '-DCMAKE_INSTALL_PREFIX=/opt/weechat' '-DENABLE_MAN=ON' '-DENABLE_HEADLESS=ON'
-- The C compiler identification is GNU 13.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.1.0") 
-- Looking for include file langinfo.h
-- Looking for include file langinfo.h - found
-- Looking for include file sys/resource.h
-- Looking for include file sys/resource.h - found
-- Looking for include file malloc.h
-- Looking for include file malloc.h - found
-- Looking for malloc_trim
-- Looking for malloc_trim - not found
-- Looking for mallinfo
-- Looking for mallinfo - not found
-- Looking for mallinfo2
-- Looking for mallinfo2 - not found
-- Looking for eat_newline_glitch
-- Looking for eat_newline_glitch - found
-- Found GCRYPT: -lgcrypt -lgpg-error  
-- Found ZLIB: /lib/libz.so (found version "1.3.1") 
-- Checking for module 'libzstd'
--   Found libzstd, version 1.5.5
-- Checking for module 'libcjson'
--   Package 'libcjson', required by 'virtual:world', not found
CMake Error at cmake/FindPkgConfig.cmake:463 (message):
  A required package was not found
Call Stack (most recent call first):
  cmake/FindPkgConfig.cmake:643 (_pkg_check_modules_internal)
  CMakeLists.txt:231 (pkg_check_modules)

-- Configuring incomplete, errors occurred!
```

**Debian**

```
+ cmake .. -DCMAKE_INSTALL_PREFIX=/opt/weechat -DENABLE_MAN=ON -DENABLE_HEADLESS=ON
-- The C compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1") 
-- Looking for include file langinfo.h
-- Looking for include file langinfo.h - found
-- Looking for include file sys/resource.h
-- Looking for include file sys/resource.h - found
-- Looking for include file malloc.h
-- Looking for include file malloc.h - found
-- Looking for malloc_trim
-- Looking for malloc_trim - found
-- Looking for mallinfo
-- Looking for mallinfo - found
-- Looking for mallinfo2
-- Looking for mallinfo2 - found
-- Looking for eat_newline_glitch
-- Looking for eat_newline_glitch - found
-- Found GCRYPT: -L/usr/lib/x86_64-linux-gnu -lgcrypt  
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.13") 
-- Checking for module 'libzstd'
--   Found libzstd, version 1.5.4
-- Checking for module 'libcjson'
--   Package 'libcjson', required by 'virtual:world', not found
CMake Error at cmake/FindPkgConfig.cmake:463 (message):
  A required package was not found
Call Stack (most recent call first):
  cmake/FindPkgConfig.cmake:643 (_pkg_check_modules_internal)
  CMakeLists.txt:231 (pkg_check_modules)


-- Configuring incomplete, errors occurred!
```